### PR TITLE
Speed up build, fix about page, Revalidate homepage in own route, useCdn false on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ TODO:
 - `about` is my personal static homepage about me
 
 ## Deployment
+
 - Auto deploys to vercel on merge to main!
 
-
 ## Revalidation
-Since we are using Next.js static pages to generate the website at build time, changes made in the CMS need to trigger a re-build of the affected pages. We use Next incremental ISR feature for this with Sanity webhooks. 
 
-There are two webhooks I set up: 1 for development and 1 for production. The development hook uses ngrok to expose a local host site (localhost://3000) to the internet for sanity webhooks to trigger. You cannot use a webhook with localhost (obviously). To set it up: 
+Since we are using Next.js static pages to generate the website at build time, changes made in the CMS need to trigger a re-build of the affected pages. We use Next incremental ISR feature for this with Sanity webhooks.
+
+There are two webhooks I set up: 1 for development and 1 for production. The development hook uses ngrok to expose a local host site (localhost://3000) to the internet for sanity webhooks to trigger. You cannot use a webhook with localhost (obviously). To set it up:
 
 1. Create a production build and start the next server: `yarn build && yarn start`
 2. Run: `yarn ngrok-start`

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,24 @@
-module.exports = {
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
+
+module.exports = withBundleAnalyzer({
   images: {
     domains: ['cdn.sanity.io'],
   },
-};
+  reactStrictMode: true,
+  modularizeImports: {
+    '@mui/icons-material': {
+      transform: '@mui/icons-material/{{member}}',
+    },
+    lodash: {
+      transform: 'lodash/{{member}}',
+    },
+  },
+  compiler: {
+    removeConsole: {
+      exclude: ['error', 'warn', 'info'],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "analyze": "ANALYZE=true next build",
     "build": "yarn generate && next build",
     "dev": "concurrently \"next dev -p 3333\" \"yarn generate --watch \"{components,pages}/**/*{.ts,.tsx}\"\"",
     "format": "npx prettier --write . --ignore-path .gitignore",
@@ -8,9 +9,9 @@
     "graphql-deploy": "sanity graphql deploy",
     "lint": "next lint -- --ignore-path .gitignore",
     "lint:fix": "npm run format && npm run lint -- --fix",
+    "ngrok-start": "ngrok http 3000",
     "start": "next start",
-    "type-check": "tsc --noEmit",
-    "ngrok-start": "ngrok http 3000"
+    "type-check": "tsc --noEmit"
   },
   "prettier": {
     "semi": true,
@@ -26,15 +27,12 @@
     "@sanity/image-url": "^1.0.2",
     "@sanity/vision": "^3.1.4",
     "@sanity/webhook": "^2.0.0",
-    "@tailwindcss/typography": "^0.5.9",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "clsx": "^1.2.1",
-    "concurrently": "^8.0.1",
     "dotenv": "^16.0.3",
     "graphql": "^16.6.0",
     "next": "^13.1.1",
     "next-sanity": "^3.1.9",
-    "next-sanity-image": "^6.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sanity": "^3.1.4",
@@ -45,9 +43,11 @@
     "@graphql-codegen/cli": "^3.3.0",
     "@graphql-codegen/client-preset": "^3.0.0",
     "@graphql-codegen/introspection": "3.0.1",
+    "@next/bundle-analyzer": "^13.4.1",
     "@types/react": "^18.0.26",
     "@typescript-eslint/parser": "^5.59.0",
     "autoprefixer": "^10.4.14",
+    "concurrently": "^8.0.1",
     "eslint": "^8.38.0",
     "eslint-config-next": "13.0.8-canary.5",
     "eslint-config-prettier": "^8.8.0",

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -3,7 +3,7 @@ import { styled } from '@mui/material/styles';
 import clsx from 'clsx';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
 import { useRouter } from 'next/router';
-import * as React from 'react';
+import React from 'react';
 
 // From Next-material UI GitHub example
 const Anchor = styled('a')({});

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,6 +1,5 @@
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import * as React from 'react';
 
 export default function LoadingSpinner() {
   return (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -18,39 +18,26 @@ import {
   Typography,
 } from '@mui/material';
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
 import { useRef, useState } from 'react';
 import { graphql } from 'src/gql/gql';
 import { GetNavBarCollectionsQuery } from 'src/gql/graphql';
 import useCollectionSlug from 'src/hooks/useCollectionSlug';
-import useRoutePath from 'src/hooks/useRoutePath';
 import { GET_COLLECTIONS_SORT } from 'src/utils/constants';
 
 import Link from './Link';
 import LoadingSpinner from './LoadingSpinner';
 
 /*
-if the slug and currentSlug are both equal, then its current route and underline it
-if isHome is passed and the currentSlug is undefined, then underline home route
+if the href is equal to the router pathname then underline the text
 */
-function CollectionListItem({
-  isHome,
-  slug,
-  title,
-  currentSlug,
-}: {
-  isHome?: boolean;
-  slug?: string;
-  title: string;
-  currentSlug: string | string[];
-}) {
+function CollectionListItem({ title, href }: { href: string; title: string }) {
+  const { asPath } = useRouter();
   return (
     <ListItem disablePadding>
       <ListItemButton
-        href={isHome ? '/' : `/collections/${slug}`}
-        className={clsx(
-          (slug === currentSlug || (isHome && !currentSlug)) &&
-            'underline underline-offset-8'
-        )}
+        href={href}
+        className={clsx(href === asPath && 'underline underline-offset-8')}
       >
         <Typography variant="body1">{title}</Typography>
       </ListItemButton>
@@ -63,16 +50,14 @@ function CollectionList({
 }: {
   collectionData: GetNavBarCollectionsQuery;
 }) {
-  const currentSlug = useCollectionSlug();
   return (
     <List>
-      <CollectionListItem title="Home" isHome currentSlug={currentSlug} />
+      <CollectionListItem title="Home" href="/" />
       {collectionData.allCollections.map((collection, i) => (
         <CollectionListItem
           key={collection._id ?? i}
           title={collection.title}
-          slug={collection.slug.current}
-          currentSlug={currentSlug}
+          href={`/collections/${collection.slug.current}`}
         />
       ))}
     </List>
@@ -108,7 +93,7 @@ export default function NavBar() {
     }
   );
   const collectionSlug = useCollectionSlug();
-  const path = useRoutePath();
+  const { pathname } = useRouter();
 
   return (
     <AppBar position="static" color="transparent">
@@ -121,7 +106,8 @@ export default function NavBar() {
         <Box sx={{ flexGrow: 1 }} />
         <div
           className={clsx(
-            (collectionSlug || path === '/') && 'underline underline-offset-8',
+            (collectionSlug || pathname === '/') &&
+              'underline underline-offset-8',
             'hidden cursor-pointer p-1 sm:block'
           )}
           onClick={() => {
@@ -139,7 +125,7 @@ export default function NavBar() {
         </div>
         <div
           className={clsx(
-            path === '/about' && 'underline underline-offset-8',
+            pathname === '/about' && 'underline underline-offset-8',
             'hidden cursor-pointer p-1 sm:block'
           )}
         >
@@ -210,6 +196,10 @@ export default function NavBar() {
             {collectionData && (
               <CollectionList collectionData={collectionData} />
             )}
+            <Typography variant="h4" className="font-bold">
+              About
+            </Typography>
+            <CollectionListItem title="Home" href="/about" />
           </DialogContent>
         </Dialog>
       </Toolbar>

--- a/src/components/NextImage.tsx
+++ b/src/components/NextImage.tsx
@@ -1,5 +1,4 @@
 import Image, { ImageProps } from 'next/image';
-import React from 'react';
 import type { Image as SanityImage } from 'sanity';
 
 import { urlForImage } from '../sanity/lib/image';

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import React from 'react';
 
 export default function PageTitle({
   title,

--- a/src/pages/api/revalidate.ts
+++ b/src/pages/api/revalidate.ts
@@ -38,8 +38,9 @@ export default async function handler(
     switch (type) {
       case 'collections':
         // always revalidate homepage too since it uses collections data
-        console.log(`Updating routes: ${type} with slug ${slug} and homepage`);
+        console.log(`Updating routes: ${type} with slug ${slug}`);
         await res.revalidate(`/collections/${slug}`);
+        console.log('Updating homepage route');
         await res.revalidate('/');
         return res.json({
           message: `Revalidated "${type}" with slug "${slug}" and homepage`,

--- a/src/pages/api/revalidateHome.ts
+++ b/src/pages/api/revalidateHome.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Data = {
+  message: string;
+};
+
+/*
+ * This endpoint is called by myself when I want to revalidate the homepage only. It's hacky but allows 2 functions to be called so we get around the 10s timeout.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  try {
+    if (req.headers.secret !== process.env.SANITY_WEBHOOK_SECRET) {
+      console.warn('Invalid token');
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    console.log('Updating homepage route...');
+    await res.revalidate('/', { unstable_onlyGenerated: true });
+    return res.json({ message: 'Revalidated homepage' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: err.message });
+  }
+}

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -14,7 +14,9 @@ import { GET_COLLECTION } from 'src/queries/GetCollection';
 export default function SeriesIdPage({
   collection,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
-  console.debug(`CollectionId rendering: ${JSON.stringify(collection, undefined, 2)}`);
+  console.debug(
+    `CollectionId rendering: ${JSON.stringify(collection, undefined, 2)}`
+  );
   return (
     <>
       <PageTitle

--- a/src/sanity/env.ts
+++ b/src/sanity/env.ts
@@ -15,7 +15,8 @@ export const readToken = process.env.SANITY_API_READ_TOKEN;
 
 export const previewSecretDocumentId: `${string}.${string}` = 'preview.secret';
 
-export const useCdn = true;
+// the goal here to use the CDN in the browser and not in the server so that browser calls are cached, but the server calls for incremental ISR are not
+export const useCdn = typeof window !== undefined ? true : false;
 
 function assertValue<T>(v: T | undefined, errorMessage: string): T {
   if (v === undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,6 +1761,13 @@
     prop-types "^15.8.1"
     react-is "^18.2.0"
 
+"@next/bundle-analyzer@^13.4.1":
+  version "13.4.1"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-13.4.1.tgz#b565f042b9623268e2891f529c144e5c152049d0"
+  integrity sha512-wbSVjc1RM43vLuvMLZL2hSq6+76VgyVWqgpgk4AlJM//KjynVMezo+c6HI8tRzMI0p0txzDtSUA3na32fuY67A==
+  dependencies:
+    webpack-bundle-analyzer "4.7.0"
+
 "@next/env@13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.3.0.tgz#cc2e49f03060a4684ce7ec7fd617a21bc5b9edba"
@@ -1887,6 +1894,11 @@
     picocolors "^1.0.0"
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
+
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.21"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.21.tgz#5de5a2385a35309427f6011992b544514d559aa1"
+  integrity sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==
 
 "@popperjs/core@^2.11.7":
   version "2.11.7"
@@ -2271,16 +2283,6 @@
   integrity sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==
   dependencies:
     defer-to-connect "^2.0.0"
-
-"@tailwindcss/typography@^0.5.9":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.9.tgz#027e4b0674929daaf7c921c900beee80dbad93e8"
-  integrity sha512-t8Sg3DyynFysV9f4JDOVISGsjazNb48AeIYQwcL+Bsq5uf4RYL75C1giZ43KISjeDGBaTN3Kxh7Xj/vRSMJUUg==
-  dependencies:
-    lodash.castarray "^4.4.0"
-    lodash.isplainobject "^4.0.6"
-    lodash.merge "^4.6.2"
-    postcss-selector-parser "6.0.10"
 
 "@tanstack/react-virtual@3.0.0-beta.53":
   version "3.0.0-beta.53"
@@ -2747,12 +2749,12 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.0.2, acorn-walk@^8.1.1:
+acorn-walk@^8.0.0, acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.0, acorn@^8.8.1:
+acorn@^8.0.4, acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.0, acorn@^8.8.1:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
@@ -3482,6 +3484,11 @@ commander@^4.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 common-tags@1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
@@ -3737,10 +3744,17 @@ dataloader@2.2.2, dataloader@^2.1.0, dataloader@^2.2.2:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
   integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
 
-date-fns@^2.26.1, date-fns@^2.29.3:
+date-fns@^2.26.1:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
+
+date-fns@^2.29.3:
+  version "2.30.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 date-now@1.0.1:
   version "1.0.1"
@@ -3987,6 +4001,11 @@ dset@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.2.tgz#89c436ca6450398396dc6538ea00abc0c54cd45a"
   integrity sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==
+
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 duplexify@^3.5.0, duplexify@^3.6.0:
   version "3.7.1"
@@ -5159,6 +5178,13 @@ gunzip-maybe@^1.4.1:
     pumpify "^1.3.3"
     through2 "^2.0.3"
 
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -6027,11 +6053,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.castarray@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
-  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -6295,6 +6316,11 @@ moment@^2.29.4:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6353,13 +6379,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
-
-next-sanity-image@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/next-sanity-image/-/next-sanity-image-6.0.0.tgz#38968317aa294fd06c7ff2e9df64ef8c8d0b3255"
-  integrity sha512-U4fl8CfJRgsUh3sJGoxgVrJ4bovCZDmWsjwowzDYbf66ci97j1mjdB+i3pz2CGFz//qbfmG8v2XL6dsYx1xFBg==
-  dependencies:
-    "@sanity/image-url" "^1.0.2"
 
 next-sanity@^3.1.9:
   version "3.1.9"
@@ -6615,6 +6634,11 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optimism@^0.16.2:
   version "0.16.2"
@@ -6966,14 +6990,6 @@ postcss-nested@6.0.0:
   integrity sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==
   dependencies:
     postcss-selector-parser "^6.0.10"
-
-postcss-selector-parser@6.0.10:
-  version "6.0.10"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
-  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
-  dependencies:
-    cssesc "^3.0.0"
-    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.10, postcss-selector-parser@^6.0.11:
   version "6.0.11"
@@ -7857,6 +7873,15 @@ simple-wcswidth@^1.0.1:
   resolved "https://registry.yarnpkg.com/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz#8ab18ac0ae342f9d9b629604e54d2aa1ecb018b2"
   integrity sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==
 
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -8385,6 +8410,11 @@ toggle-selection@^1.0.6:
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
 
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
+
 tough-cookie@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
@@ -8760,6 +8790,21 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
+webpack-bundle-analyzer@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.7.0.tgz#33c1c485a7fcae8627c547b5c3328b46de733c66"
+  integrity sha512-j9b8ynpJS4K+zfO5GGwsAcQX4ZHpWV+yRiHDiL+bE0XHJ8NiPYLTNVQdlFYWxtpg9lfAQNlwJg16J9AJtFSXRg==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
 whatwg-encoding@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
@@ -8876,6 +8921,11 @@ ws@8.13.0, ws@^8.11.0, ws@^8.12.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+ws@^7.3.1:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
@@ -8961,10 +9011,23 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
 
-yargs@^17.0.0, yargs@^17.3.0, yargs@^17.7.1:
+yargs@^17.0.0, yargs@^17.3.0:
   version "17.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
   integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.1:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
All this fixes up the ability to revalidate and use ISR (incremental static rebuilds) when changes are made in Sanity

- Fix about page links
- Speed up build by removing unused packages, better `next.config.js`
- Revalidate homepage in its own api route so we get 20s instead of 10s to update routes. This is because 2 serverless functions are triggered.
- `useCdn` needs to be false on the server, so ISR hits the real data and not the cache. If we switch to using server components, this could become a slight issue