### PR TITLE
Revalidate homepage in its own API route, useCdn false on server

### DIFF
--- a/src/pages/api/revalidateHome.ts
+++ b/src/pages/api/revalidateHome.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Data = {
+  message: string;
+};
+
+/*
+ * This endpoint is called by myself when I want to revalidate the homepage only. It's hacky but allows 2 functions to be called so we get around the 10s timeout.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  try {
+    if (req.headers.secret !== process.env.SANITY_WEBHOOK_SECRET) {
+      console.warn('Invalid token');
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+    console.log('Updating homepage route...');
+    await res.revalidate('/', { unstable_onlyGenerated: true });
+    return res.json({ message: 'Revalidated homepage' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ message: err.message });
+  }
+}

--- a/src/sanity/env.ts
+++ b/src/sanity/env.ts
@@ -15,7 +15,8 @@ export const readToken = process.env.SANITY_API_READ_TOKEN;
 
 export const previewSecretDocumentId: `${string}.${string}` = 'preview.secret';
 
-export const useCdn = true;
+// the goal here to use the CDN in the browser and not in the server so that browser calls are cached, but the server calls for incremental ISR are not
+export const useCdn = typeof window !== undefined ? true : false;
 
 function assertValue<T>(v: T | undefined, errorMessage: string): T {
   if (v === undefined) {


### PR DESCRIPTION
- Revalidate the homepage route in its own API so that we can get 10s to revalidate each page on its own. This is slightly hacky but helps a lot
- useCdn false on the server side so that the ISR works correctly and fetches fresh data. If we use server components in the future this could become an issue
- use unstable gen API options in `revalidate` call which I believe creates/deletes routes correctly for ISR!!