### PR TITLE
Revalidate script, getStaticPaths blocking ISR

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "npm run format && npm run lint -- --fix",
     "ngrok-start": "ngrok http 3000",
     "start": "next start",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "revalidate": "ts-node-esm scripts/revalidate.ts"
   },
   "prettier": {
     "semi": true,

--- a/scripts/revalidate.ts
+++ b/scripts/revalidate.ts
@@ -1,0 +1,58 @@
+// Usage: ts-node scripts/revalidate.ts <slug>
+// Script revalidates all the routes for a given collection slug across different domains which next doesn't handle :(
+
+import * as dotenv from 'dotenv';
+
+// Load environment variables from .env file
+dotenv.config();
+
+const slug = process.argv[2];
+
+if (!slug) {
+  console.error('Missing slug argument');
+  process.exit(1);
+}
+
+const baseUrlToRevalidate = [
+  'https://www.jaisalfriedman.com',
+  'https://jaisal.xyz',
+];
+
+async function revalidateRoute(url: string, route: string) {
+  const resp = await fetch(`${url}/api/revalidateRoute`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      secret: process.env.SANITY_WEBHOOK_SECRET ?? '',
+      route: route,
+    },
+  });
+  if (resp.status === 200) {
+    console.log(`Revalidation successful for ${route}`);
+  } else {
+    console.error(
+      `Revalidation failed for ${route} on ${url} with status ${resp.status}`
+    );
+    throw new Error(await resp.text());
+  }
+}
+
+async function revalidate() {
+  console.log(`Revalidating ${slug}`);
+  await Promise.all(
+    baseUrlToRevalidate.map(async (url) => {
+      await revalidateRoute(url, '/');
+      await revalidateRoute(url, `/collections/${slug}`);
+    })
+  );
+}
+
+revalidate()
+  .then(() => {
+    console.log('Revalidation complete');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/pages/collections/[id].tsx
+++ b/src/pages/collections/[id].tsx
@@ -105,6 +105,7 @@ export async function getStaticPaths(): Promise<GetStaticPathsResult> {
       throw err;
     });
   if (!data) {
+    // will invalidate all new builds and error out
     throw new Error('getStaticPaths empty return value');
   }
 
@@ -112,6 +113,6 @@ export async function getStaticPaths(): Promise<GetStaticPathsResult> {
     paths: data.allCollections.map((collection) => ({
       params: { id: collection?.slug.current ?? '' }, // shouldn't happen could be bad if it starts null'ing out
     })),
-    fallback: false,
+    fallback: 'blocking', // force a rebuild if the path doesn't exist
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "ts-node": {
+    // these options are overrides used only by ts-node
+    // same as the --compilerOptions flag and the TS_NODE_COMPILER_OPTIONS environment variable
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ES6",


### PR DESCRIPTION
- Revalidate script that takes a slug and revalidates all pages across all domains that I use
- getStaticPaths should block and thus re-render newly created pages